### PR TITLE
Add manually-triggered SPM dependency update workflow

### DIFF
--- a/.github/workflows/update-spm.yml
+++ b/.github/workflows/update-spm.yml
@@ -1,0 +1,47 @@
+name: Update Swift Packages
+
+# Manually-triggered job that bumps the SPM pins in Patchcord.xcodeproj to the
+# latest versions allowed by the constraints in project.pbxproj, then opens a
+# PR with the new Package.resolved. Dispatch from the Actions tab when you
+# want to refresh dependencies.
+#
+# Implementation: maximbilan/xcode-spm-update. Required on Xcode 16+ because
+# `xcodebuild -resolvePackageDependencies` stopped reliably bumping versions
+# there; the action routes around it via `swift package update` on a synthetic
+# manifest.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: update
+        uses: maximbilan/xcode-spm-update@v1
+        with:
+          project: Patchcord.xcodeproj
+          # Once you've confirmed which Xcode versions the runner offers, pin
+          # the one your team uses so Package.resolved's format/originHash
+          # matches what local Xcode expects. Example: xcode-version: '16.4'.
+          # Leaving it unset uses the runner's default Xcode.
+
+      - name: Open pull request
+        if: steps.update.outputs.dependencies-changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: deps/spm-update
+          delete-branch: true
+          commit-message: 'chore: update Swift package dependencies'
+          title: 'Update Swift package dependencies'
+          body: |
+            Automated bump of Swift Package Manager pins.
+
+            ${{ steps.update.outputs.changed-count }} package(s) changed.
+          labels: dependencies


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/update-spm.yml`, a `workflow_dispatch`-only job that calls [`maximbilan/xcode-spm-update@v1`](https://github.com/maximbilan/xcode-spm-update) to refresh `Package.resolved` for `Patchcord.xcodeproj`.
- When any pin would change, the job opens a follow-up PR via `peter-evans/create-pull-request@v6` against `deps/spm-update`.
- No schedule — dispatch manually from the Actions tab when you want to refresh dependencies.

## Why
`xcodebuild -resolvePackageDependencies` stopped reliably bumping SPM versions on Xcode 16+. The action routes around it by handing a synthetic `Package.swift` to `swift package update` so the real PubGrub solver does the work, then writes the result back into the project's internal workspace.

## Test plan
- [ ] Merge this PR.
- [ ] Go to Actions → "Update Swift Packages" → **Run workflow** on `main`.
- [ ] Confirm one of:
  - the job logs "All dependencies already up to date" and finishes without opening a PR, **or**
  - a follow-up PR opens on the `deps/spm-update` branch with a fresh `Package.resolved`.
- [ ] If a PR is opened, check it out locally and open Patchcord in Xcode. If Xcode silently re-resolves on first open (format/originHash mismatch), set `xcode-version:` in the workflow to match what your local Xcode produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)